### PR TITLE
Fix N+1 query issue in search_registered_models

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -165,13 +165,67 @@ class SqlAlchemyStore(AbstractStore):
         """
         A list of SQLAlchemy query options that can be used to eagerly
         load the following registered model attributes
-        when fetching a registered model: ``registered_model_tags``.
+        when fetching a registered model: ``registered_model_tags`` and
+        ``registered_model_aliases``.
         """
         # Use a subquery load rather than a joined load in order to minimize the memory overhead
         # of the eager loading procedure. For more information about relationship loading
         # techniques, see https://docs.sqlalchemy.org/en/13/orm/
         # loading_relationships.html#relationship-loading-techniques
-        return [sqlalchemy.orm.subqueryload(SqlRegisteredModel.registered_model_tags)]
+        return [
+            sqlalchemy.orm.subqueryload(SqlRegisteredModel.registered_model_tags),
+            sqlalchemy.orm.subqueryload(SqlRegisteredModel.registered_model_aliases),
+        ]
+
+    @classmethod
+    def _get_latest_versions_for_models(cls, session, model_names: list[str]) -> dict[str, list]:
+        """
+        Batch-fetch the latest model version per stage for multiple registered models.
+
+        Uses a SQL window function to compute the latest version per (name, stage) directly
+        in the database, avoiding N+1 queries and Python-side iteration through all versions.
+        """
+        if not model_names:
+            return {}
+
+        row_num = (
+            sqlalchemy.func.row_number()
+            .over(
+                partition_by=[SqlModelVersion.name, SqlModelVersion.current_stage],
+                order_by=SqlModelVersion.version.desc(),
+            )
+            .label("rn")
+        )
+
+        subquery = (
+            select(SqlModelVersion, row_num)
+            .where(
+                SqlModelVersion.name.in_(model_names),
+                SqlModelVersion.current_stage != STAGE_DELETED_INTERNAL,
+            )
+            .subquery()
+        )
+
+        query = (
+            select(SqlModelVersion)
+            .join(
+                subquery,
+                sqlalchemy.and_(
+                    SqlModelVersion.name == subquery.c.name,
+                    SqlModelVersion.version == subquery.c.version,
+                ),
+            )
+            .where(subquery.c.rn == 1)
+            .options(*cls._get_eager_model_version_query_options())
+        )
+
+        latest_versions = session.execute(query).scalars().all()
+
+        result: dict[str, list] = {name: [] for name in model_names}
+        for mv in latest_versions:
+            result[mv.name].append(mv)
+
+        return result
 
     @staticmethod
     def _get_eager_model_version_query_options():
@@ -385,7 +439,15 @@ class SqlAlchemyStore(AbstractStore):
             next_page_token = self._compute_next_token(
                 max_results_for_query, len(sql_registered_models), offset, max_results
             )
-            rm_entities = [rm.to_mlflow_entity() for rm in sql_registered_models][:max_results]
+
+            # Batch-fetch latest versions for all models to avoid N+1 queries
+            model_names = [rm.name for rm in sql_registered_models[:max_results]]
+            latest_versions_map = self._get_latest_versions_for_models(session, model_names)
+
+            rm_entities = [
+                rm.to_mlflow_entity(preloaded_latest_versions=latest_versions_map.get(rm.name))
+                for rm in sql_registered_models
+            ][:max_results]
             return PagedList(rm_entities, next_page_token)
 
     @classmethod


### PR DESCRIPTION
### Related Issues/PRs

Resolves #16587

### What changes are proposed in this pull request?

Fix the N+1 query problem in `search_registered_models` that caused extreme slowness when models have many versions.

**Root cause:** For each model returned by search, separate queries were triggered to lazy-load `model_versions` and `registered_model_aliases`. Additionally, the code iterated through ALL versions in Python to find the latest per stage.

**Solution:**
- Add `_get_latest_versions_for_models()` method that uses SQL `ROW_NUMBER()` window function to batch-fetch the latest version per stage for all models in a single query
- Eagerly load `registered_model_aliases` in `_get_eager_registered_model_query_options()`
- Update `SqlRegisteredModel.to_mlflow_entity()` to accept optional pre-computed latest versions

**Performance improvement with 60k versions (6 models × 10k each):**
| Version | Time | Queries |
|---------|------|---------|
| Before | 570ms | 20 |
| After | 224ms | 5 |
| **Speedup** | **2.5x** | |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Ran all 103 existing model registry tests - all pass:
```
uv run pytest tests/store/model_registry/test_sqlalchemy_store.py -v
```

Benchmark script verified performance improvement against MLflow v2.21.0.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved performance of `search_registered_models` API for models with many versions by fixing N+1 query issue (2.5x faster with 60k versions).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)